### PR TITLE
🔧 Use GitHub repository variables for Azure RG and Web App name

### DIFF
--- a/.github/workflows/deploy-to-azure.yml
+++ b/.github/workflows/deploy-to-azure.yml
@@ -41,8 +41,8 @@ jobs:
     needs: test
 
     env:
-      AZURE_WEBAPP_NAME: hoi-streamlit-chatbot-portal-001
-      AZURE_RG: hoi-streamlit-chatbot-001-rg
+      AZURE_WEBAPP_NAME: ${{ vars.AZURE_WEBAPP_NAME }}
+      AZURE_RG: ${{ vars.AZURE_RG }}
 
     steps:
       - name: ❤️ Checkout Code


### PR DESCRIPTION
Replaces hard-coded resource group and web app name with repository-level variables to allow easier redeployment.